### PR TITLE
Join the database network

### DIFF
--- a/salt/digests/config/home-deployuser-digests-containers.env
+++ b/salt/digests/config/home-deployuser-digests-containers.env
@@ -8,7 +8,7 @@ BUS_NAME={{ pillar.digests.sns.name }}
 BUS_ENV={{ pillar.elife.env }}
 COMPOSE_PROJECT_NAME=digests
 # temporarily running as root, before RDS is introduced
-DATABASE_URL=postgres://{{ pillar.elife.db.root.username }}:{{pillar.elife.db.root.password }}@localhost:5432/{{ pillar.elife.db.root.username }}
+DATABASE_URL=postgres://{{ pillar.elife.db.root.username }}:{{pillar.elife.db.root.password }}@postgres:5432/{{ pillar.elife.db.root.username }}
 DEBUG=false
 ENVIRONMENT_NAME={{ pillar.elife.env }}
 LOGGING_LEVEL={{ pillar.digests.logging.level }}

--- a/salt/digests/config/home-deployuser-digests-docker-compose.yml
+++ b/salt/digests/config/home-deployuser-digests-docker-compose.yml
@@ -11,7 +11,7 @@ services:
             - /srv/digests/var/logs:/srv/digests/var/logs
         networks:
             - default
-            #- databases
+            - databases
         ports:
             - 9000:9000
         env_file:
@@ -20,5 +20,5 @@ services:
 
 networks:
     default:
-    #databases:
-    #    external: true
+    databases:
+        external: true


### PR DESCRIPTION
(We have cookies)

The `digests_wsgi_1` container tries to connect to localhost, but this isn't the host EC2 instance: it's the container itself. To correctly connect to the `postgres` container, we need to join its network and use the `postgres` host. Databases provided by containers are on a separate network, fostering their isolation from the application.

Don't trust the build: it tests the wrong version of the formula due to https://github.com/elifesciences/builder/pull/370, I am testing this manually in Vagrant.