### PR TITLE
doubles timeout for digests_wsgi container to be considered healthy.

### DIFF
--- a/salt/digests/config/srv-digests-smoke_tests.sh
+++ b/salt/digests/config/srv-digests-smoke_tests.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 . /opt/smoke.sh/smoke.sh
 
-docker-wait-healthy digests_wsgi_1
+# lsh@2020-04: timeout should increase as the time to apply migrations increases
+timeout=60 # seconds. default 30
+docker-wait-healthy digests_wsgi_1 $timeout
 smoke_url_ok localhost/ping
 smoke_url_ok localhost/digests
 smoke_report


### PR DESCRIPTION
this is because migrations are being run as part of the application's init. The time to apply migrations and the number of migrations will affect apparent healthiness.